### PR TITLE
Fix verifyIBANFormat false positive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "costa-rica-iban",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/costa-rica-iban.min.js",
   "license": "MIT",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ export const verifyIBANLength = (iban) => {
 export const verifyIBANFormat = (iban) => {
   errorIfNotString(iban);
 
-  return (/^CR\d\d0(1|[3-8])\d{16}$/).test(iban);
+  return (/^CR\d\d0(1|[3-8])\d{16}$/).test(iban) &&
+    bankCodes.indexOf(iban.slice(5, 8)) > -1;
 };
 
 const errorOnInvalidIBAN = (iban) => {

--- a/test/criban_test.js
+++ b/test/criban_test.js
@@ -15,6 +15,8 @@ const goodIBANBank = bankCollection.find((b) => b.code === '102');
 
 const badIBAN = 'DE69 5021 0900 0123 4567 13';
 
+const deceptiveIBAN = 'CR06030500009123456789';
+
 const ambiguousIBAN = 'CR06082400009123456789';
 const ambiguousIBANBank = bankCollection.find((b) => b.code === '824');
 
@@ -58,6 +60,7 @@ describe('Costa Rica IBAN functions', () => {
     } catch(e) {
       expect(e.message).toBe('Type Error: expected string');
       expect(verifyIBANFormat(badIBAN)).toBe(false);
+      expect(verifyIBANFormat(deceptiveIBAN)).toBe(false);
       expect(verifyIBANFormat(goodIBAN)).toBe(true);
     }
   });


### PR DESCRIPTION
This PR fixes #2 where .getBankName()﻿would fail due to IBAN with correct format but bank code not on bank collection.
